### PR TITLE
break: add "exports" map for native ESM support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,15 +3,16 @@
   "version": "1.0.0",
   "repository": "lukeed/hexoid",
   "description": "A tiny (190B) and extremely fast utility to generate random IDs of fixed length",
-  "type": "module",
   "exports": {
-    "import": "./dist/index.mjs",
-    "require": "./dist/index.cjs",
-    "default": "./dist/index.cjs"
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "unpkg": "dist/index.min.js",
   "module": "dist/index.mjs",
-  "main": "dist/index.cjs",
+  "main": "dist/index.js",
   "types": "hexoid.d.ts",
   "license": "MIT",
   "author": {
@@ -24,7 +25,7 @@
   },
   "scripts": {
     "build": "bundt",
-    "test": "uvu test -i collisions"
+    "test": "uvu test -r esm -i collisions"
   },
   "files": [
     "*.d.ts",
@@ -39,6 +40,7 @@
   ],
   "devDependencies": {
     "bundt": "1.0.0",
-    "uvu": "^0.5.3"
+    "esm": "3.2.25",
+    "uvu": "0.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,15 @@
   "version": "1.0.0",
   "repository": "lukeed/hexoid",
   "description": "A tiny (190B) and extremely fast utility to generate random IDs of fixed length",
+  "type": "module",
+  "exports": {
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.cjs",
+    "default": "./dist/index.cjs"
+  },
   "unpkg": "dist/index.min.js",
   "module": "dist/index.mjs",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
   "types": "hexoid.d.ts",
   "license": "MIT",
   "author": {
@@ -18,7 +24,7 @@
   },
   "scripts": {
     "build": "bundt",
-    "test": "uvu -r esm test -i collisions"
+    "test": "uvu test -i collisions"
   },
   "files": [
     "*.d.ts",
@@ -33,7 +39,6 @@
   ],
   "devDependencies": {
     "bundt": "1.0.0",
-    "esm": "3.2.25",
-    "uvu": "0.3.4"
+    "uvu": "^0.5.3"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
-import hexoid from '../src';
+import hexoid from '../src/index.js';
 
 test('exports', () => {
 	assert.type(hexoid, 'function', 'exports function');


### PR DESCRIPTION
This PR turns hexoid into a "true" ES module while maintaining compatibility with CJS and older bundlers (e.g. Webpack v4). 

Previously, _hexoid_ presented 
(a) itself as a _CommonJS_ module when imported via the node module loader (not a problem)
(b) its ESM API when bundled using webpack (via the `module` entry point, which has priority in most configurations). That turns out to be a problem when hexoid is `require`d from another module in the dependency chain because that causes webpack to look for a CommonJS-style export, which is incompatible with the ESM default export and ultimately causes loading of the final bundle to fail.

The [conditional exports](https://nodejs.org/api/packages.html#conditional-exports) feature fixes the issue by directing module loaders to the appropriate entry point depending on whether or not the module is `import`ed or `require`d and has been available since NodeJS v12.16.0 and Webpack v5. There should be no [dual package hazard](https://nodejs.org/docs/latest/api/packages.html#dual-package-hazard) thanks to _hexoid_ being stateless and only exposing primitives.

Recent node versions now treat hexoid as a module while old node versions fall back to the `main` entry point (or, in case of older bundlers possibly `module`). 